### PR TITLE
Update target.json

### DIFF
--- a/target.json
+++ b/target.json
@@ -9,7 +9,7 @@
     }
   ],
   "inherits": {
-    "mbed-gcc": "0.1.3"
+    "mbed-gcc": "https://github.com/lancaster-university/target-mbed-gcc.git#v0.1.3"
   },
   "keywords": [
     "mbed-target:nrf51822",


### PR DESCRIPTION
See https://github.com/lancaster-university/microbit-targets/commit/5630495e44a4c8d70f369249edd97cedff6794c2

"As the yotta registry is deprecated (as per #6) we need to move away
from using it.

All of these targets have a dependency on the mbed-gcc target, which
was being fetched by the registry (defined through 'inherits'). This
patch changes the reference to explicitly use GitHub as the source
for the dependency.

This uses an HTTPS URL, which yotta will fetch with the GitHub API,
while this can cause some issues with rate limiting, it also means
a user doesn't need to setup SSH at all, which is required for
git@ URLS"